### PR TITLE
Add precompiled XTensa32 library, link into project, change partition table

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,10 @@
 [env:esp32doit-devkit-v1]
 platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2idf/platform-espressif32-2.0.2.zip
 board = esp32doit-devkit-v1
+; the most minimal app with this gargantuan libmx library does not fit within 1Mbyte.
+; change partition table to one that allows a 3MByte app.
+board_build.partitions = huge_app.csv
+
 framework = arduino
 build_unflags =
 	-std=gnu++11
@@ -19,18 +23,20 @@ build_flags =
 	-std=gnu++17
 	-fexceptions
 	# Include MX library
-	-L$PROJECT_DIR/libs/mx
+	-Llibs
 	-lmx
-	# Include MX sources
-	#-I$PROJECT_DIR/dependencies/mx/Sourcecode/include
-	#-I$PROJECT_DIR/dependencies/mx/Sourcecode/private
+	# Include MX headers
+	-Idependencies/mx/Sourcecode/include
+	-Idependencies/mx/Sourcecode/private
 
 monitor_speed = 115200
 
 extra_scripts = 
 	pre:./install-dependencies.py
 	pre:./load_pages.py
- 	pre:./build-dependencies.py
+	; do not even attempt to dynamically build libmx in order to
+	; keep your sanity and compile times as low as possible.
+ 	#pre:./build-dependencies.py
 
 lib_deps = 
 	esphome/AsyncTCP-esphome@^1.2.2


### PR DESCRIPTION
The precompiled library is compiled as noted in https://community.platformio.org/t/using-cpp-library-in-platformio/26032/17?u=maxgerhardt with `-mlongcalls` and `-Os`.

Building should result in 

```
Linking .pio\build\esp32doit-devkit-v1\firmware.elf
Retrieving maximum program size .pio\build\esp32doit-devkit-v1\firmware.elf
Checking size .pio\build\esp32doit-devkit-v1\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=         ]  13.7% (used 44756 bytes from 327680 bytes)
Flash: [========= ]  85.3% (used 2684073 bytes from 3145728 bytes)
Building .pio\build\esp32doit-devkit-v1\firmware.bin
esptool.py v3.2
Merged 25 ELF sections
============================================= [SUCCESS] Took 57.17 seconds =============================================
```

Linking takes ~60 seconds on my machine due to the size of `libmx.a`.